### PR TITLE
feat(ui): Redesign custom properties section with editable keys

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -249,28 +249,9 @@
         border-color: var(--text);
       }
 
-      .input-wrapper {
-        display: flex;
-        align-items: center;
-        gap: 8px;
-        margin-bottom: 12px;
-      }
-
-      .input-wrapper input {
-        flex-grow: 1;
-        margin-bottom: 0;
-      }
-
-      .input-wrapper button {
-        width: auto;
-        padding: 12px;
-        margin-bottom: 0;
-        min-width: 44px;
-      }
-
       .key-section {
         margin-bottom: 16px;
-        padding: 12px;
+        padding: 16px;
         border: 1px solid var(--border-color);
         border-radius: 8px;
         background: var(--input-bg);
@@ -278,10 +259,14 @@
       }
 
       .key-section h5 {
-        margin: 0 0 8px 0;
+        margin: 0 0 12px 0;
         font-size: 14px;
         font-weight: 600;
         color: var(--accent-color);
+      }
+
+      .key-section input {
+        margin-bottom: 12px;
       }
 
       .key-section.hidden {
@@ -447,76 +432,88 @@
         display: flex;
         flex-direction: column;
         gap: 12px;
-        margin-bottom: 16px;
-        padding: 16px;
+        padding: 20px;
         border: 2px solid var(--border-color);
         border-radius: 12px;
-        background: var(--input-bg);
+        background: var(--section-bg);
+        position: relative;
+        margin-bottom: 24px;
+      }
+
+      .custom-value-item .key-header {
+        font-size: 16px;
+        font-weight: 600;
+        color: var(--accent-color);
+        padding: 8px 16px;
+        cursor: text;
+        border: 2px solid var(--accent-color);
+        border-radius: 8px 8px 0 0;
         transition: all 0.2s ease;
-        width: 100%;
+        min-height: 24px;
+        background: transparent;
+        word-wrap: break-word;
+        overflow-wrap: break-word;
+        position: relative;
+        margin-bottom: 0;
+        text-align: center;
+        max-width: 100%;
         box-sizing: border-box;
+        white-space: pre-line;
+        line-height: 1.4;
       }
 
-      .custom-value-item:hover {
+      .custom-value-item .key-header:focus {
+        outline: none;
+        background: var(--input-bg);
+        color: var(--accent-color);
         border-color: var(--accent-color);
-        box-shadow: 0 4px 16px rgba(102, 126, 234, 0.15);
-        transform: translateY(-1px);
       }
 
-      .custom-value-item .input-row {
-        display: flex;
-        align-items: center;
-        gap: 12px;
-        margin-bottom: 12px;
-        width: 100%;
+      .custom-value-item .key-header:hover {
+        background: var(--input-bg);
+        color: var(--accent-color);
+        border-color: var(--accent-color);
+      }
+
+      .custom-value-item .value-label {
+        font-weight: 500;
+        color: var(--text);
+        margin-bottom: 4px;
       }
 
       .custom-value-item input {
-        flex: 1;
-        margin-bottom: 0;
-        padding: 12px 14px;
-        font-size: 14px;
+        width: 100%;
+        padding: 12px;
         border: 2px solid var(--border-color);
         border-radius: 8px;
-        min-height: 44px;
+        background: var(--input-bg);
+        color: var(--text);
+        font-size: 14px;
+        box-sizing: border-box;
+        margin-bottom: 16px;
       }
 
       .custom-value-item input:focus {
         outline: none;
         border-color: var(--accent-color);
-        box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.2);
-      }
-
-      .custom-value-item input:placeholder-shown {
-        border-color: var(--border-color);
-        background: var(--input-bg);
-      }
-
-      .custom-value-item input:not(:placeholder-shown) {
         background: var(--section-bg);
-        border-color: var(--accent-color);
-      }
-
-      .custom-value-item .key-input {
-        flex: 0 0 45%;
-      }
-
-      .custom-value-item .value-input {
-        flex: 0 0 55%;
       }
 
       .custom-value-item .remove-btn {
         background: var(--error-color);
         color: white;
         border: none;
+        padding: 10px 16px;
         border-radius: 8px;
-        padding: 10px 20px;
-        font-size: 13px;
         cursor: pointer;
+        font-size: 14px;
+        font-weight: 500;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 8px;
+        margin-top: 8px;
         transition: all 0.2s ease;
-        width: 100%;
-        box-sizing: border-box;
-        font-weight: 600;
       }
 
       .custom-value-item .remove-btn:hover {
@@ -611,13 +608,11 @@
         <div class="key-header">
           <h5>🔵 OpenAI API Key</h5>
         </div>
-        <div class="input-wrapper">
-          <input
-            id="openaiKey"
-            type="password"
-            placeholder="Enter OpenAI API Key"
-          />
-        </div>
+        <input
+          id="openaiKey"
+          type="password"
+          placeholder="Enter OpenAI API Key"
+        />
         <div class="button-row">
           <button class="view-btn" id="openaiEyeBtn">👁️ View Key</button>
           <button class="delete-btn" id="deleteOpenaiBtn">🗑️ Delete Key</button>
@@ -628,13 +623,11 @@
         <div class="key-header">
           <h5>🟡 Gemini API Key</h5>
         </div>
-        <div class="input-wrapper">
-          <input
-            id="geminiKey"
-            type="password"
-            placeholder="Enter Gemini API Key"
-          />
-        </div>
+        <input
+          id="geminiKey"
+          type="password"
+          placeholder="Enter Gemini API Key"
+        />
         <div class="button-row">
           <button class="view-btn" id="geminiEyeBtn">👁️ View Key</button>
           <button class="delete-btn" id="deleteGeminiBtn">🗑️ Delete Key</button>

--- a/popup.js
+++ b/popup.js
@@ -81,43 +81,112 @@ function createCustomValueItem(key = '', value = '') {
   const item = document.createElement('div');
   item.className = 'custom-value-item';
 
-  // Create input row wrapper
-  const inputRow = document.createElement('div');
-  inputRow.className = 'input-row';
+  // Create contenteditable key header
+  const keyHeader = document.createElement('div');
+  keyHeader.contentEditable = true;
+  keyHeader.textContent = key || 'Enter key name here';
+  keyHeader.className = 'key-header';
 
-  const keyInput = document.createElement('input');
-  keyInput.type = 'text';
-  keyInput.placeholder = 'Key (e.g., project_name)';
-  keyInput.className = 'key-input';
-  keyInput.value = key;
+  // Create label for value
+  const valueLabel = document.createElement('label');
+  valueLabel.textContent = 'Description of key:';
+  valueLabel.className = 'value-label';
 
+  // Create value input
   const valueInput = document.createElement('input');
   valueInput.type = 'text';
-  valueInput.placeholder = 'Value (e.g., MyProject)';
+  valueInput.placeholder = 'Enter description here';
   valueInput.className = 'value-input';
   valueInput.value = value;
+  valueInput.id = `description-${Date.now()}-${Math.random()}`;
+  valueLabel.htmlFor = valueInput.id;
 
+  // Create remove button with text and icon
   const removeBtn = document.createElement('button');
   removeBtn.className = 'remove-btn';
-  removeBtn.textContent = '🗑️';
-  removeBtn.style.display = 'flex';
+  removeBtn.innerHTML = '🗑️ Remove Custom Property';
   removeBtn.onclick = () => item.remove();
 
   // Clear validation errors when input changes
   const clearValidation = () => {
-    keyInput.style.borderColor = '';
     valueInput.style.borderColor = '';
   };
 
-  keyInput.addEventListener('input', clearValidation);
   valueInput.addEventListener('input', clearValidation);
 
-  // Add inputs to input row
-  inputRow.appendChild(keyInput);
-  inputRow.appendChild(valueInput);
+  // Update key header when it changes
+  keyHeader.addEventListener('input', () => {
+    const currentText = keyHeader.textContent;
 
-  // Add input row and remove button to item
-  item.appendChild(inputRow);
+    // If completely empty, set default text
+    if (!currentText.trim()) {
+      keyHeader.textContent = 'Enter key name here';
+      return;
+    }
+
+    // If the text contains the default text, remove it and keep only user input
+    if (currentText.includes('Enter key name here')) {
+      const userInput = currentText.replace('Enter key name here', '').trim();
+      if (userInput) {
+        // Save cursor position before replacing text
+        const selection = window.getSelection();
+        const range = selection.getRangeAt(0);
+        const cursorOffset = range.startOffset;
+
+        // Replace the text
+        keyHeader.textContent = userInput;
+
+        // Restore cursor position at the end of the text
+        const newRange = document.createRange();
+        newRange.selectNodeContents(keyHeader);
+        newRange.collapse(false); // false = collapse to end
+        selection.removeAllRanges();
+        selection.addRange(newRange);
+      } else {
+        keyHeader.textContent = 'Enter key name here';
+        return;
+      }
+    }
+
+    // Limit to 15 words max
+    const words = currentText.trim().split(/\s+/);
+    if (words.length > 15) {
+      // Take first 15 words and add line breaks every 5 words for readability
+      const limitedWords = words.slice(0, 15);
+      const lines = [];
+      for (let i = 0; i < limitedWords.length; i += 5) {
+        lines.push(limitedWords.slice(i, i + 5).join(' '));
+      }
+      keyHeader.textContent = lines.join('\n');
+    }
+  });
+
+  // Auto-remove empty items when they lose focus
+  keyHeader.addEventListener('blur', () => {
+    const key = keyHeader.textContent.trim();
+    const valueInput = item.querySelector('.value-input');
+    const value = valueInput.value.trim();
+
+    // If both key and value are empty/default, remove the item
+    if ((!key || key === 'Enter key name here') && !value) {
+      item.remove();
+    }
+  });
+
+  valueInput.addEventListener('blur', () => {
+    const key = keyHeader.textContent.trim();
+    const value = valueInput.value.trim();
+
+    // If both key and value are empty/default, remove the item
+    if ((!key || key === 'Enter key name here') && !value) {
+      item.remove();
+    }
+  });
+
+  // Add elements directly to item
+  item.appendChild(keyHeader);
+  item.appendChild(valueLabel);
+  item.appendChild(valueInput);
   item.appendChild(removeBtn);
 
   return item;
@@ -131,36 +200,38 @@ function saveCustomValues() {
   const items = customValuesList.querySelectorAll('.custom-value-item');
 
   items.forEach((item, index) => {
-    const keyInput = item.querySelector('.key-input');
+    const keyHeader = item.querySelector('.key-header');
     const valueInput = item.querySelector('.value-input');
-    const key = keyInput.value.trim();
+    const key = keyHeader.textContent.trim();
     const value = valueInput.value.trim();
 
-    if (!key && !value) {
-      // Skip completely empty rows
-      return;
+    // Check if key is empty or just the default text
+    if (!key || key === 'Enter key name here') {
+      // Remove completely empty items or items with default text
+      if (!value) {
+        item.remove(); // Remove the empty item from UI
+        return;
+      } else {
+        // Has value but no valid key
+        errors.push(`Row ${index + 1}: Key is required when value is provided`);
+        keyHeader.style.borderColor = 'var(--error-color)';
+        return;
+      }
     }
 
-    // Allow blank values for user-added entries
-    if (!key && value) {
-      errors.push(`Row ${index + 1}: Key is required when value is provided`);
-      keyInput.style.borderColor = 'var(--error-color)';
-      return;
-    }
-
+    // Allow blank values for valid keys
     if (key && !value) {
-      // Allow blank values - this is valid
-      // Just add the key with empty value
+      // Valid key with empty value - this is allowed
     }
 
     if (tempCustomValues.some(existing => existing.key === key)) {
       errors.push(`Duplicate key: "${key}"`);
-      keyInput.style.borderColor = 'var(--error-color)';
+      keyHeader.style.borderColor = 'var(--error-color)';
       return;
     }
 
     // Reset border color if valid
-    keyInput.style.borderColor = '';
+    keyHeader.style.borderColor = '';
     valueInput.style.borderColor = '';
 
     // Add the key-value pair (value can be empty)

--- a/popup.js
+++ b/popup.js
@@ -501,7 +501,7 @@ saveKeyBtn.addEventListener('click', () => {
     apiSection.style.display = 'none';
     generateSection.style.display = 'block';
     generateBtn.style.display = 'block';
-    changeKeyBtn.innerHTML = '�� Change API Keys';
+    changeKeyBtn.innerHTML = '🔑 Change API Keys';
 
     openaiKeyInput.value = openaiKey ? getMaskedKey(openaiKey) : '';
     geminiKeyInput.value = geminiKey ? getMaskedKey(geminiKey) : '';


### PR DESCRIPTION
**Purpose**: To improve the user experience of adding and managing custom properties by redesigning the UI from simple input fields to a more intuitive, card-based layout with an editable title.

**Key Files Changed**:
*   `popup.html`: Updated the HTML and CSS for the custom properties section to support the new card-based design with an editable header.
*   `popup.js`: Reworked the logic for creating and managing custom properties to handle the new `contenteditable` key header and implement auto-removal of empty items.

**Summary of Changes**:
*   Replaced the key-value input pair with a card-like component.
*   The "key" is now a `contenteditable` header, providing a more intuitive editing experience.
*   The "value" is now a description field under the key.
*   Implemented auto-removal of empty custom property cards when they lose focus (on blur).
*   Added a 15-word limit to the key to maintain readability.
*   Updated validation logic in `saveCustomValues` to accommodate the new `contenteditable` key.
*   Refactored the HTML for API key inputs, removing redundant wrappers.

**Risk Management**:
Low. The changes are scoped to the UI for managing custom properties within the extension's popup. The core logic of how these values are stored and used in prompts remains the same.

**Breaking Changes**:
None. The underlying data structure for saved custom values is unchanged. This is a UI/UX enhancement.

**Env Variables**:
None.

**Refactoring**:
*   The custom properties UI has been refactored from a simple row of inputs to a more structured and intuitive card component.
*   The `createCustomValueItem` function was completely overhauled to build the new component and its associated event listeners.
*   Simplified the HTML structure for the API key input sections.